### PR TITLE
Add trailing slash to fake_s3_upload url

### DIFF
--- a/buckets/test/urls.py
+++ b/buckets/test/urls.py
@@ -3,5 +3,5 @@ from buckets.test import views
 
 urlpatterns = [
     url(r'^', include('buckets.urls')),
-    url(r'^media/s3/uploads$', views.fake_s3_upload, name='fake_s3_upload'),
+    url(r'^media/s3/uploads/$', views.fake_s3_upload, name='fake_s3_upload'),
 ]

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -90,9 +90,9 @@ def test_content_via_save(make_dirs):  # noqa
 
 
 def test_urls():
-    assert reverse('fake_s3_upload') == '/media/s3/uploads'
+    assert reverse('fake_s3_upload') == '/media/s3/uploads/'
 
-    resolved = resolve('/media/s3/uploads')
+    resolved = resolve('/media/s3/uploads/')
     assert resolved.func.__name__ == views.fake_s3_upload.__name__
 
 


### PR DESCRIPTION
The standard `signed_url` view includes a trailing slash. I believe the test `fake_s3_upload` view should follow suit.

I discovered this when writing a script against my development machine. http://localhost:8000/media/s3/uploads/ returns a `404` while http://localhost:8000/media/s3/uploads succeeds.  This is out of line with the other URL in the project (along with all URLs in my other project).