### PR TITLE
Make key a required argument for storage.get_signed_url()

### DIFF
--- a/buckets/storage.py
+++ b/buckets/storage.py
@@ -73,7 +73,7 @@ class S3Storage(Storage):
         else:
             return True
 
-    def get_signed_url(self, key=None):
+    def get_signed_url(self, key):
         dir = ''
         if '/' in key:
             dir = key[:key.rfind('/') + 1]

--- a/buckets/test/storage.py
+++ b/buckets/test/storage.py
@@ -46,7 +46,7 @@ class FakeS3Storage(object):
         path = os.path.join(self.dir, 'uploads', key)
         return os.path.exists(path)
 
-    def get_signed_url(self, key=None):
+    def get_signed_url(self, key):
         dir = ''
         if '/' in key:
             dir = key[:key.rfind('/') + 1]


### PR DESCRIPTION
The signature of the `get_signed_url` describes the `key` argument as an optional argument defaulting to `None`, however the second line `if '/' in key` would raise an error if `key == None`.