### PR TITLE
Set fake_s3_upload view to be CSRF exempt

### DIFF
--- a/buckets/test/views.py
+++ b/buckets/test/views.py
@@ -1,8 +1,10 @@
 from django.core.files.storage import default_storage
+from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 from django.http import HttpResponse
 
 
+@csrf_exempt
 @require_POST
 def fake_s3_upload(request):
     key = request.POST.get('key')


### PR DESCRIPTION
Currently, the `fake_s3_upload` requires a CSRF token. This does not match the reality of the production S3 URL that would take its place in production. When writing a script to run against Django-Buckets in both the test or production environment, this is made more difficult due to special considerations needed to work around the discrepancy. I believe it would be ideal for the test environment to match the production environment as closely as possible.