### PR TITLE
add string interpolation to enable string translation

### DIFF
--- a/buckets/widgets.py
+++ b/buckets/widgets.py
@@ -2,6 +2,7 @@ import json
 from os.path import basename
 from django.forms import widgets
 from django.utils.safestring import mark_safe
+from django.utils.translation import ugettext as _
 from django.conf import settings
 
 
@@ -12,13 +13,13 @@ class S3FileUploadWidget(widgets.TextInput):
         '   {mime_lookup}'
         '   <div class="file-links">'
         '       <a class="file-link" href="{file_url}">{file_name}</a>'
-        '       <a class="file-remove" href="#">(Remove)</a>'
+        '       <a class="file-remove" href="#">%s</a>'
         '   </div>'
         '   <input class="file-url" type="hidden" value="{file_url}"'
         '          id="{element_id}" name="{name}" />'
         '   <input class="file-input" type="file" />'
         '</div>'
-    )
+    ) % _("(Remove)")
 
     class Media:
         js = (


### PR DESCRIPTION
This makes it possible to translate the `Remove` string displayed to users when they upload a new resource using the `S3FileUploadWidget`.

Screenshot of string in the Italian translation:
![image](https://user-images.githubusercontent.com/16849118/28145036-0eb79fe4-6724-11e7-8a1e-c4ffbc76fc2f.png)
