### PR TITLE
Add include_package_data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,7 @@ setup(
     author_email=author_email,
     packages=get_packages(package),
     package_data=get_package_data(package),
+    include_package_data=True,
     install_requires=[
         'boto3==1.4.4'
     ],


### PR DESCRIPTION
This PR adds `include_package_data=True` to `setup()` to resolve an issue where static files in the package weren't being installed properly, resulting in a system state of `pip` showing the updated package version but outdated static files still in place.