### PR TITLE
Re-enable submit button after upload error

### DIFF
--- a/buckets/static/buckets/js/script.js
+++ b/buckets/static/buckets/js/script.js
@@ -56,6 +56,7 @@
         errorList.appendChild(errorMessage);
 
         el.insertBefore(errorList, el.firstChild);
+        disableSubmit(el, false);
     }
 
     function update(el, fileUrl) {


### PR DESCRIPTION
As reported in https://github.com/Cadasta/cadasta-platform/issues/1761, it's currently not possible to upload another file after an upload has errored. 

The change added here will solve the issue by re-enabling the submit button during error handling.