### PR TITLE
Fix XLSForm URLs

### DIFF
--- a/buckets/static/buckets/js/script.js
+++ b/buckets/static/buckets/js/script.js
@@ -126,7 +126,7 @@
                     
                 error(el, errorMsg)
             } else {
-                var fileUrl = data.url + '/' + data.fields.key;
+                var fileUrl = data.url + data.fields.key;
                 update(el, fileUrl);
             }
         });


### PR DESCRIPTION
Fixing the bug @MappingKat mentioned on Slack.

With a recent update in boto3, the addressing scheme of S3 buckets changed from `https://s3.{aws region}.amazonaws.com/{bucket name}` to `https://{bucket name}.s3.amazonaws.com/`. 

The old scheme did not end with a forward slash, so we appended one when constructing the URL before storing it in the database. The new scheme, however, ends with a forward slash, resulting in two slashes after the hostname and thus breaking the URL. 

